### PR TITLE
Import force_unicode from correct location

### DIFF
--- a/django_remote_forms/utils.py
+++ b/django_remote_forms/utils.py
@@ -1,5 +1,5 @@
 from django.utils.functional import Promise
-from django.utils.translation import force_unicode
+from django.utils.encoding import force_unicode
 
 
 def resolve_promise(o):


### PR DESCRIPTION
it appears `force_unicode` has been removed from `django.utils.translation`, `django.utils.encoding` is the correct location for this function.
