### PR TITLE
fixed import force_unicode

### DIFF
--- a/django_remote_forms/utils.py
+++ b/django_remote_forms/utils.py
@@ -1,5 +1,5 @@
 from django.utils.functional import Promise
-from django.utils.translation import force_unicode
+from django.utils.encoding import force_unicode
 
 
 def resolve_promise(o):


### PR DESCRIPTION
Fixed force_unicode import that is not more correct in django 1.5.
