### PR TITLE
fixed getting the parent of RemoteFileField for dict conversion

### DIFF
--- a/django_remote_forms/fields.py
+++ b/django_remote_forms/fields.py
@@ -144,7 +144,7 @@ class RemoteEmailField(RemoteCharField):
 
 class RemoteFileField(RemoteField):
     def as_dict(self):
-        field_dict = super(RemoteField, self).as_dict()
+        field_dict = super(RemoteFileField, self).as_dict()
 
         field_dict['max_length'] = self.field.max_length
 


### PR DESCRIPTION
The RemoteFileField super() function was returning the parent of the parent...must have been a typo.
