### PR TITLE
Changed widget titles for Email, Number and URL inputs

### DIFF
--- a/django_remote_forms/widgets.py
+++ b/django_remote_forms/widgets.py
@@ -47,17 +47,29 @@ class RemoteHiddenInput(RemoteInput):
 
 class RemoteEmailInput(RemoteInput):
     def as_dict(self):
-        return super(RemoteEmailInput, self).as_dict()
+        widget_dict = super(RemoteEmailInput, self).as_dict()
+
+        widget_dict['title'] = 'TextInput'
+        
+        return widget_dict
 
 
 class RemoteNumberInput(RemoteInput):
     def as_dict(self):
-        return super(RemoteNumberInput, self).as_dict()
+        widget_dict = super(RemoteNumberInput, self).as_dict()
+
+        widget_dict['title'] = 'TextInput'
+
+        return widget_dict
 
 
 class RemoteURLInput(RemoteInput):
     def as_dict(self):
-        return super(RemoteURLInput, self).as_dict()
+        widget_dict = super(RemoteURLInput, self).as_dict()
+
+        widget_dict['title'] = 'TextInput'
+
+        return widget_dict
 
 
 class RemoteMultipleHiddenInput(RemoteHiddenInput):


### PR DESCRIPTION
Adding these new widgets in django 1.6 breaks django-remote-form API compatibility with old JS clients.
I changed all widget titles to 'TextInput', so, old JS may interpret them as usual text inputs. 
