### PR TITLE
FIX-ERROR: ImportError: cannot import name 'force_unicode' from 'djan…

### DIFF
--- a/django_remote_forms/__init__.py
+++ b/django_remote_forms/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'Carlo Costino, Tareque Hossain'
-__version__ = (0, 0, 1)
+__version__ = (0, 0, 2)
 
 import logging
 

--- a/django_remote_forms/fields.py
+++ b/django_remote_forms/fields.py
@@ -40,7 +40,7 @@ class RemoteField(object):
         try:
             remote_widget_class = getattr(widgets, remote_widget_class_name)
             remote_widget = remote_widget_class(self.field.widget, field_name=self.field_name)
-        except Exception, e:
+        except Exception as e:
             logger.warning('Error serializing %s: %s', remote_widget_class_name, str(e))
             widget_dict = {}
         else:

--- a/django_remote_forms/forms.py
+++ b/django_remote_forms/forms.py
@@ -138,7 +138,7 @@ class RemoteForm(object):
             try:
                 remote_field_class = getattr(fields, remote_field_class_name)
                 remote_field = remote_field_class(field, form_initial_field_data, field_name=name)
-            except Exception, e:
+            except Exception as e:
                 logger.warning('Error serializing field %s: %s', remote_field_class_name, str(e))
                 field_dict = {}
             else:

--- a/django_remote_forms/utils.py
+++ b/django_remote_forms/utils.py
@@ -1,5 +1,9 @@
 from django.utils.functional import Promise
-from django.utils.encoding import force_unicode
+
+try:
+    from django.utils.encoding import force_unicode  # Django in Python 2
+except ImportError:
+    from django.utils.encoding import force_text as force_unicode  # Django in Python 3
 
 
 def resolve_promise(o):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
 
 setup(
     name='django-remote-forms',
-    version='0.0.1',
+    version='0.0.2',
     description='A platform independent form serializer for Django.',
     author='WiserTogether Tech Team',
     author_email='tech@wisertogether.com',


### PR DESCRIPTION
FIX ERROR:

`ImportError                               Traceback (most recent call last)
<ipython-input-1-09c905c2a5de> in <module>
----> 1 from django_remote_forms.forms import RemoteForm
      2 
      3 from india.forms import FormImporterCPM
      4 
      5 form = FormImporterCPM()

~/.virtualenvs/zina-flow/lib/python3.7/site-packages/django_remote_forms/forms.py in <module>
      2 
      3 from django_remote_forms import fields, logger
----> 4 from django_remote_forms.utils import resolve_promise
      5 
      6 

~/.virtualenvs/zina-flow/lib/python3.7/site-packages/django_remote_forms/utils.py in <module>
      1 from django.utils.functional import Promise
----> 2 from django.utils.encoding import force_unicode
      3 
      4 
      5 def resolve_promise(o):

ImportError: cannot import name 'force_unicode' from 'django.utils.encoding' (/home/leon/.virtualenvs/zina-flow/lib/python3.7/site-packages/django/utils/encoding.py)
`